### PR TITLE
chore: limit orientation to portrait only

### DIFF
--- a/guilt-tripper/Info.plist
+++ b/guilt-tripper/Info.plist
@@ -31,8 +31,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
Phone doesn't support rotation, so is only displayed in portrait mode